### PR TITLE
Fix utf-8 encoding errors on update and file xmls.

### DIFF
--- a/update_modifier.py
+++ b/update_modifier.py
@@ -146,8 +146,8 @@ class WsusXmlModifier(object):
         
     def __modify_extended_update_response(self, content, request):
         print('Adding fake update metadata to GetExtendedUpdateInfoResult')
-        update_xml = self.__gen_extended_update_response_xml()
-        file_xml = self.__gen_file_location_xml(request.getAllHeaders()['host'])
+        update_xml = self.__gen_extended_update_response_xml().encode('utf-8')
+        file_xml = self.__gen_file_location_xml(request.getAllHeaders()['host']).encode('utf-8')
         
         if '<Updates>' in content:
             # There are real updates in the WSUS response, so add ours to the end


### PR DESCRIPTION
Using the proxy on a machine with existing pending updates seems to break
when modifying the XML's with `__modify_extended_update_response()`,
specifically in the `content.replace()` methods.

This commits fixes the decoding problem by encoding them with utf-8.

Version Info: 

```
# cat /etc/issue
Kali GNU/Linux Rolling 
```

```
~ # python --version
Python 2.7.11
```

Stack Trace:

```
# python wsuspect_proxy.py psexec 8080
2016-02-15 10:41:45+0200 [-] Log opened.
2016-02-15 10:41:45+0200 [-] InterceptingProxyFactory starting on 8080
2016-02-15 10:41:45+0200 [-] Starting factory <intercepting_proxy.InterceptingProxyFactory instance at 0x7f271d2cb830>

[...]

2016-02-15 10:42:51+0200 [-] Adding fake update metadata to GetExtendedUpdateInfoResult
2016-02-15 10:42:51+0200 [InterceptingProxyClient,client] Unhandled Error
    Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/twisted/python/log.py", line 101, in callWithLogger
        return callWithContext({"system": lp}, func, *args, **kw)
      File "/usr/lib/python2.7/dist-packages/twisted/python/log.py", line 84, in callWithContext
        return context.call({ILogContext: newCtx}, func, *args, **kw)
      File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 118, in callWithContext
        return self.currentContext().callWithContext(ctx, func, *args, **kw)
      File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 81, in callWithContext
        return func(*args,**kw)
    --- <exception caught here> ---
      File "/usr/lib/python2.7/dist-packages/twisted/internet/posixbase.py", line 597, in _doReadOrWrite
        why = selectable.doRead()
      File "/usr/lib/python2.7/dist-packages/twisted/internet/tcp.py", line 209, in doRead
        return self._dataReceived(data)
      File "/usr/lib/python2.7/dist-packages/twisted/internet/tcp.py", line 215, in _dataReceived
        rval = self.protocol.dataReceived(data)
      File "/usr/lib/python2.7/dist-packages/twisted/protocols/basic.py", line 578, in dataReceived
        why = self.rawDataReceived(data)
      File "/usr/lib/python2.7/dist-packages/twisted/web/http.py", line 525, in rawDataReceived
        self.handleResponseEnd()
      File "/opt/wsuspect-proxy/intercepting_proxy.py", line 99, in handleResponseEnd
        self.father.run_response_modifiers()
      File "/opt/wsuspect-proxy/intercepting_proxy.py", line 149, in run_response_modifiers
        m.modify_response(self)
      File "/opt/wsuspect-proxy/update_modifier.py", line 144, in modify_response
        content = fn(content, request)
      File "/opt/wsuspect-proxy/update_modifier.py", line 154, in __modify_extended_update_response
        content = content.replace('</Updates>', '%s</Updates>' % update_xml)
    exceptions.UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 10905: ordinal not in range(128)

2016-02-15 10:42:51+0200 [InterceptingProxyClient,client] Unhandled Error
    Traceback (most recent call last):
      File "wsuspect_proxy.py", line 59, in <module>
        reactor.run()
      File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 1194, in run
        self.mainLoop()
      File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 1206, in mainLoop
        self.doIteration(t)
      File "/usr/lib/python2.7/dist-packages/twisted/internet/epollreactor.py", line 396, in doPoll
        log.callWithLogger(selectable, _drdw, selectable, fd, event)
    --- <exception caught here> ---
      File "/usr/lib/python2.7/dist-packages/twisted/python/log.py", line 101, in callWithLogger
        return callWithContext({"system": lp}, func, *args, **kw)
      File "/usr/lib/python2.7/dist-packages/twisted/python/log.py", line 84, in callWithContext
        return context.call({ILogContext: newCtx}, func, *args, **kw)
      File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 118, in callWithContext
        return self.currentContext().callWithContext(ctx, func, *args, **kw)
      File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 81, in callWithContext
        return func(*args,**kw)
      File "/usr/lib/python2.7/dist-packages/twisted/internet/posixbase.py", line 610, in _doReadOrWrite
        self._disconnectSelectable(selectable, why, inRead)
      File "/usr/lib/python2.7/dist-packages/twisted/internet/posixbase.py", line 258, in _disconnectSelectable
        selectable.connectionLost(failure.Failure(why))
      File "/usr/lib/python2.7/dist-packages/twisted/internet/tcp.py", line 479, in connectionLost
        self._commonConnection.connectionLost(self, reason)
      File "/usr/lib/python2.7/dist-packages/twisted/internet/tcp.py", line 293, in connectionLost
        protocol.connectionLost(reason)
      File "/usr/lib/python2.7/dist-packages/twisted/web/http.py", line 477, in connectionLost
        self.handleResponseEnd()
      File "/opt/wsuspect-proxy/intercepting_proxy.py", line 94, in handleResponseEnd
        data = self.father.response_buffer.getvalue()
    exceptions.AttributeError: 'str' object has no attribute 'getvalue'


```
