### PR TITLE
fix: Added support for non proxy-aware clients.

### DIFF
--- a/intercepting_proxy.py
+++ b/intercepting_proxy.py
@@ -172,6 +172,10 @@ class InterceptingProxyRequest(proxy.ProxyRequest):
     def process(self):
         host = None
         port = None
+
+        if not self.uri.startswith("http://") and not self.uri.startswith("https://"):
+            self.uri = "http://" + self.getHeader("Host") + self.uri
+
         parsed_uri = urlparse(self.uri)
         self.uri = urlunparse(('', '', parsed_uri.path, parsed_uri.params, parsed_uri.query, parsed_uri.fragment)) or "/"
 


### PR DESCRIPTION
Quick fix to support non proxy-aware clients.

Now working with L2 and L3 mitm arsenal such as Arpspoof + Iptables or with Bettercap

Bettercap command line:
`bettercap -T 192.168.1.100 -X --custom-redirection 'TCP 8530 8080'`

